### PR TITLE
!ship moth returns results for terran ship "behemoth" as opposed to the cathaargh ship "moth"

### DIFF
--- a/munin/loadable.py
+++ b/munin/loadable.py
@@ -171,8 +171,12 @@ class loadable(object):
 
     def get_ship_from_db(self,ship_name):
         query="SELECT * FROM ship WHERE name ILIKE %s ORDER BY id"
-        self.cursor.execute(query,("%"+ship_name+"%",))
+        self.cursor.execute(query,(ship_name,))
         ship=self.cursor.dictfetchone()
+        
+        if not ship:
+            self.cursor.execute(query,("%"+ship_name+"%",))
+            ship=self.cursor.dictfetchone()
 
         if not ship and ship_name[-1].lower() == 's':
             ship_name = ship_name[0:-1]


### PR DESCRIPTION
The problem here is simple: We are looking up ships by partial matches, and then order by ID. Since round 62 then there is a ship called "Moth" which has a higher ID than the ship "Behemoth". This fix tries to go and find a ship by its full name first, then falls back to the partial matching logic we had before.
